### PR TITLE
remove ruby dependecy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -133,6 +133,3 @@ dependencies:
     tags:
       - basic-postgres
 
-  - role: rvm1-ansible
-    tags:
-      - ruby


### PR DESCRIPTION
The uploaded fix is not present in public repository, so we added the stackbuilders repo  in the haystak devops project.
Currently we are downloading two versions of rvm_ansible-galaxy. One that is hardcoded in this meta/main.yml, and one where we specify our rvm_ansible repo.
We need to remove the first one. 
