### PR TITLE
Set deploy user UID from variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for sb-base
+deploy_user_id: 1000
+deploy_group_id: 1000

--- a/tasks/bootstrap-tasks.yml
+++ b/tasks/bootstrap-tasks.yml
@@ -1,0 +1,109 @@
+---
+- name: Disallow SSH password authentication
+  lineinfile:
+    dest=/etc/ssh/sshd_config
+    regexp="^PasswordAuthentication"
+    line="PasswordAuthentication no"
+    state=present
+
+- name: Disallow root SSH access
+  lineinfile:
+   dest=/etc/ssh/sshd_config
+   regexp="^PermitRootLogin"
+   line="PermitRootLogin no"
+   state=present
+  notify:
+    - restart sshd
+
+- name: Dist upgrade packges
+  apt: upgrade=dist
+
+- name: Install packges
+  apt: name={{ item }} state=present
+  with_items:
+    - vim
+    - tmux
+    - htop
+    - atop
+    - ufw
+    - emacs24-nox
+    - atsar
+    - git
+    - curl
+
+- name: Set collide_user_name
+  shell: "awk -v val={{ deploy_user_id }} -F ':' '$3==val{print $1}' /etc/passwd"
+  register: collide_user_name
+
+- name: Set collide_group_name
+  shell: "getent group {{ deploy_group_id }} | cut -d: -f1"
+  register: collide_group_name
+
+- name: Remove user to avoid uid collide
+  user:
+    name="{{ collide_user_name.stdout_lines[0] }}" state=absent
+  when: collide_user_name.stdout_lines[0] is defined
+
+- name: Remove group to avoid gid collide
+  group:
+    name="{{ collide_group_name.stdout_lines[0] }}" state=absent
+  when: collide_group_name.stdout_lines[0] is defined
+
+- name: Create deploy user group
+  group:
+    name={{ user_group_app_directory }} gid={{ deploy_group_id }} state=present
+
+- name: Add deploy user user
+  user:
+    name={{ deploy_username }} comment="Unprivileged {{ deploy_username }} User"
+    uid={{ deploy_user_id }} groups={{ deploy_username }} shell=/bin/bash
+
+- name: Set up authorized_keys for the deploy user user
+  authorized_key: user={{ deploy_username }} key="{{ item }}"
+  with_file:
+    - keys/deploy_users
+    - keys/ci-{{ app_environment }}
+
+- name: Replace ssh files with github deployer ssh
+  template: 
+    src="{{ item.src }}" dest="{{ item.dest }}" mode="{{ item.mode }}"
+    owner="{{ user_owner_app_directory }}" group="{{ user_group_app_directory }}"
+  with_items:
+    - { src: 'keys/github-pub', dest: '/home/{{ deploy_username }}/.ssh/id_rsa.pub', mode: '0644' }
+    - { src: 'keys/github-keys', dest: '/home/{{ deploy_username }}/.ssh/id_rsa', mode: '0600' }
+
+- name: Ensure github.com is a known host
+  lineinfile:
+    dest: /home/{{ deploy_username }}/.ssh/known_hosts
+    create: yes
+    state: present
+    line: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
+    regexp: "^github\\.com"
+    group: '{{ user_group_app_directory }}'
+    owner: '{{ deploy_username }}'
+
+- name: Set hostname to host-specific variable
+  hostname: name={{ hostname }}
+  when: hostname is defined
+  tags:
+    - bootstrap
+    - set-hostname
+
+- name: Set hostname to host name in inventory
+  hostname: name={{ inventory_hostname }}
+  when: hostname is undefined
+  tags:
+    - bootstrap
+    - set-hostname
+
+- name: Enable ufw
+  ufw: state=enabled policy=deny
+
+- name: Open general ports
+  ufw: rule=allow port={{ item }}  proto=tcp
+  with_items:
+    - "{{ ports | default([22]) }}"
+
+- name: Open ports by IP
+  ufw: rule=allow port={{ item.value.port }}  proto=tcp src={{ item.value.ip }}
+  with_dict: "{{ port_ips | default({}) }}"

--- a/tasks/haskell-stack-tasks.yml
+++ b/tasks/haskell-stack-tasks.yml
@@ -1,0 +1,11 @@
+- name: Add FPCO Deb Key
+  apt_key: url=https://s3.amazonaws.com/download.fpcomplete.com/debian/fpco.key state=present
+
+- name: Add FPCO Deb repository
+  apt_repository: repo='deb http://download.fpcomplete.com/debian/jessie stable main' state=present
+
+- name: Update packges
+  apt: update_cache=yes
+
+- name: Install Stack packges
+  apt: name=stack state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,201 +1,27 @@
 ---
-- name: Add OS user
-  user: name=administrator comment="Privileged Administrator user" uid=1001 group=sudo shell=/bin/bash
+- include: prebootstrap-tasks.yml
   remote_user: root
   tags:
     - prebootstrap
 
-- name: Enable default repos
-  apt_repository: repo='deb http://ftp.debian.org/debian/ jessie main' state=present
-  remote_user: root
-  tags:
-    - prebootstrap
-
-- name: Update packges
-  apt: update_cache=yes
-  tags:
-    - prebootstrap
-
-- name: Install sudo package
-  apt: name={{ item }} state=present
-  remote_user: root
-  with_items:
-    - sudo
-  tags:
-    - prebootstrap
-
-- name: Sudo without password
-  lineinfile: "dest=/etc/sudoers state=present regexp='^%sudo ALL' line='%sudo ALL=(ALL) NOPASSWD: ALL'"
-  remote_user: root
-  tags:
-    - prebootstrap
-
-- name: Set up authorized_keys for the administrator user
-  authorized_key: user=administrator
-                  key="{{ item }}"
-  with_file:
-    - keys/administrators
-  tags:
-    - prebootstrap
-
-- name: Disallow SSH password authentication
+- include: bootstrap-tasks.yml
   remote_user: administrator
   become: yes
   become_method: sudo
-  lineinfile:
-    dest=/etc/ssh/sshd_config
-    regexp="^PasswordAuthentication"
-    line="PasswordAuthentication no"
-    state=present
   tags:
     - bootstrap
 
-- name: Disallow root SSH access
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  lineinfile:
-   dest=/etc/ssh/sshd_config
-   regexp="^PermitRootLogin"
-   line="PermitRootLogin no"
-   state=present
-  notify:
-    - restart sshd
-  tags:
-    - bootstrap
-
-- name: Dist upgrade packges
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  apt: upgrade=dist
-  tags:
-    - bootstrap
-
-- name: Install packges
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  apt: name={{ item }} state=present
-  with_items:
-    - vim
-    - tmux
-    - htop
-    - atop
-    - ufw
-    - emacs24-nox
-    - atsar
-    - git
-    - curl
-  tags:
-    - bootstrap
-
-- name: Create deploy user group
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  group: name={{ user_group_app_directory }} state=present
-  tags:
-    - bootstrap
-
-- name: Add deploy user user
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  user: name={{ deploy_username }} comment="Unprivileged {{ deploy_username }} User" uid=2000 groups={{ deploy_username }} shell=/bin/bash generate_ssh_key=yes ssh_key_bits=2048 ssh_key_file=.ssh/id_rsa
-  tags:
-    - bootstrap
-
-- name: Set up authorized_keys for the deploy user user
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  authorized_key: user={{ deploy_username }}
-                  key="{{ item }}"
-  with_file:
-    - keys/deploy_users
-    - keys/ci-{{ app_environment }}
-  tags:
-    - bootstrap
-
-- name: Replace ssh files with github deployer ssh
-  remote_user: "{{ deploy_username }}"
-  template: src="{{ item.src }}" dest="{{ item.dest }}" mode="{{ item.mode }}" owner="{{ user_owner_app_directory }}" group="{{ user_group_app_directory }}"
-  with_items:
-    - { src: 'keys/github-pub', dest: '/home/{{ deploy_username }}/.ssh/id_rsa.pub', mode: '0644' }
-    - { src: 'keys/github-keys', dest: '/home/{{ deploy_username }}/.ssh/id_rsa', mode: '0600' }
-  tags:
-    - bootstrap
-
-- name: Ensure github.com is a known host
-  become: yes
-  become_method: sudo
-  remote_user: administrator
-  lineinfile:
-    dest: /home/{{ deploy_username }}/.ssh/known_hosts
-    create: yes
-    state: present
-    line: "{{ lookup('pipe', 'ssh-keyscan -t rsa github.com') }}"
-    regexp: "^github\\.com"
-    group: '{{ user_group_app_directory }}'
-    owner: '{{ deploy_username }}'
-  tags:
-    - bootstrap
-
-- name: Set hostname to host-specific variable
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  hostname: name={{ hostname }}
-  when: hostname is defined
-  tags:
-    - bootstrap
-    - set-hostname
-
-- name: Set hostname to host name in inventory
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  hostname: name={{ inventory_hostname }}
-  when: hostname is undefined
-  tags:
-    - bootstrap
-    - set-hostname
-
-- name: Enable ufw
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  ufw: state=enabled policy=deny
-  tags:
-    - bootstrap
-
-- name: Open general ports
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  ufw: rule=allow port={{ item }}  proto=tcp
-  with_items:
-    - "{{ ports }}"
-  tags:
-    - bootstrap
-
-- name: Open ports by IP
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  ufw: rule=allow port={{ item.value.port }}  proto=tcp src={{ item.value.ip }}
-  with_dict: port_ips
-  tags:
-    - db-bootstrap
 
 - name: Set up application deploy directory
   remote_user: administrator
   become: yes
   become_method: sudo
-  file: path=/var/projects state=directory owner="{{ user_owner_app_directory }}" group="{{ user_group_app_directory }}" mode=0775
+  file: 
+    path=/var/projects state=directory
+    owner="{{ user_owner_app_directory }}" group="{{ user_group_app_directory }}" mode=0775
   tags:
     - create-app-directory
+
 
 - name: Install common Haskell build dependencies
   remote_user: administrator
@@ -209,37 +35,14 @@
   tags:
     - haskell-build-dependencies
 
-- name: Add FPCO Deb Key
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  apt_key: url=https://s3.amazonaws.com/download.fpcomplete.com/debian/fpco.key state=present
-  tags:
-    - haskell-stack
 
-- name: Add FPCO Deb repository
-  apt_repository: repo='deb http://download.fpcomplete.com/debian/jessie stable main' state=present
+- include: haskell-stack-tasks.yml
   remote_user: administrator
   become: yes
   become_method: sudo
   tags:
     - haskell-stack
 
-- name: Update packges
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  apt: update_cache=yes
-  tags:
-    - haskell-stack
-
-- name: Install Stack packges
-  remote_user: administrator
-  become: yes
-  become_method: sudo
-  apt: name=stack state=present
-  tags:
-    - haskell-stack
 
 - name: Install rvm dependencies
   remote_user: administrator

--- a/tasks/prebootstrap-tasks.yml
+++ b/tasks/prebootstrap-tasks.yml
@@ -1,0 +1,25 @@
+---
+- name: Add OS user
+  user: 
+    name=administrator comment="Privileged Administrator user" shell=/bin/bash
+    uid={{ deploy_user_id + 1 }} group=sudo
+
+- name: Enable default repos
+  apt_repository: repo='deb http://ftp.debian.org/debian/ jessie main' state=present
+
+- name: Update packges
+  apt: update_cache=yes
+
+- name: Install sudo package
+  apt: name={{ item }} state=present
+  with_items:
+    - sudo
+
+- name: Sudo without password
+  lineinfile: "dest=/etc/sudoers state=present regexp='^%sudo ALL' line='%sudo ALL=(ALL) NOPASSWD: ALL'"
+
+- name: Set up authorized_keys for the administrator user
+  authorized_key: user=administrator
+                  key="{{ item }}"
+  with_file:
+    - keys/administrators


### PR DESCRIPTION
- [x] Remove users/groups if their id collides with the desired UID/GID for deploy user
- [x] Set the UID number for deploy user from a variable
- [x] Set the UID number for administrator user to be one number higher that deploy user's UID

This is do to the necessity of having the same uid for deploy user on dynamic Ops and Nfs server
