### PR TITLE
Use define deploy_username on bootstrap and add add-remove-keys task

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ This tag contains more advance setup tasks, such as:
 ### - nginx-https
 - external dependency jdauphant.nginx to install and manage nginx configuration
 
+### - add-remove-keys
+- deploy listed ssh-keys into key files, first remove/add  unneeded/needed keys on keys/* folder
+
 ## Files you need to create
 You should have the following list of files containing the SSH public-keys for both the administrator and deployer users, respectively.
 

--- a/tasks/bootstrap-tasks.yml
+++ b/tasks/bootstrap-tasks.yml
@@ -53,17 +53,20 @@
 - name: Create deploy user group
   group:
     name={{ user_group_app_directory }} gid={{ deploy_group_id }} state=present
+  when: deploy_username is defined
 
 - name: Add deploy user
   user:
     name={{ deploy_username }} comment="Unprivileged {{ deploy_username }} User"
     uid={{ deploy_user_id }} group={{ user_group_app_directory }} shell=/bin/bash
+  when: deploy_username is defined
 
 - name: Set up authorized_keys for the deploy user user
   authorized_key: user={{ deploy_username }} key="{{ item }}"
   with_file:
     - keys/deploy_users
     - keys/ci-{{ app_environment }}
+  when: deploy_username is defined
 
 - name: Replace ssh files with github deployer ssh
   template: 
@@ -72,6 +75,7 @@
   with_items:
     - { src: 'keys/github-pub', dest: '/home/{{ deploy_username }}/.ssh/id_rsa.pub', mode: '0644' }
     - { src: 'keys/github-keys', dest: '/home/{{ deploy_username }}/.ssh/id_rsa', mode: '0600' }
+  when: deploy_username is defined
 
 - name: Ensure github.com is a known host
   lineinfile:
@@ -82,6 +86,7 @@
     regexp: "^github\\.com"
     group: '{{ user_group_app_directory }}'
     owner: '{{ deploy_username }}'
+  when: deploy_username is defined
 
 - name: Set hostname to host-specific variable
   hostname: name={{ hostname }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,3 +60,38 @@
     - libxslt1-dev
   tags:
     - ruby-dependencies
+
+
+- name: Set up authorized_keys for the administrator user
+  remote_user: administrator
+  become: yes
+  become_method: sudo
+  authorized_key: user=administrator key="{{ item }}" state=present exclusive=yes
+  with_file:
+    - keys/administrators
+  tags:
+    - add-remove-keys
+
+
+- name: Set up authorized_keys for the deploy user
+  remote_user: administrator
+  become: yes
+  become_method: sudo
+  authorized_key: user={{ deploy_username }} key="{{ item }}" state=present exclusive=yes
+  with_file:
+    - keys/deploy_users
+  when: deploy_username is defined
+  tags:
+    - add-remove-keys
+
+
+- name: Set up authorized_keys for ci on deploy user
+  remote_user: administrator
+  become: yes
+  become_method: sudo
+  authorized_key: user={{ deploy_username }} key="{{ item }}" state=present
+  with_file:
+    - keys/ci-{{ app_environment }}
+  when: deploy_username is defined
+  tags:
+    - add-remove-keys


### PR DESCRIPTION
Use _deploy_username is defined_, to deploy to servers which do not need deploy_user and app_folder, it is for cases like redis or database servers.
Also added the tag to add/remove ssh keys.  
