### PR TITLE
Add sudo as secondary group to admin

### DIFF
--- a/tasks/prebootstrap-tasks.yml
+++ b/tasks/prebootstrap-tasks.yml
@@ -1,9 +1,11 @@
 ---
 - name: Add OS user
   user:
-    name="{{ admin_user }}" comment="Privileged Administrator user"
-    shell=/bin/bash
-    group=sudo
+    name: "{{ admin_user }}"
+    comment: "Privileged Administrator user"
+    shell: /bin/bash
+    groups: sudo
+    append: yes
 
 - name: Enable default repos
   apt_repository: repo='deb http://ftp.debian.org/debian/ jessie main' state=present


### PR DESCRIPTION
Currently `admin` user doesn't includes `admin` group.

```
admin@jessie:~$ groups
sudo
```

Expected

```
admin@jessie:~$ groups
admin sudo
```