### PR TITLE
Make sure that the admin ssh keys are present

### DIFF
--- a/tasks/bootstrap-tasks.yml
+++ b/tasks/bootstrap-tasks.yml
@@ -1,4 +1,11 @@
 ---
+- name: Make sure that the authorized_keys are present for the admin user
+  authorized_key:
+    user: "{{ admin_user }}"
+    key: "{{ item }}"
+  with_file:
+    - keys/administrators
+
 - name: Disallow SSH password authentication
   lineinfile:
     dest=/etc/ssh/sshd_config


### PR DESCRIPTION
Make sure that the admin ssh keys are present in the bootstrap, in amazon is common that the images are not allowed to connect to the root user, so is not posible run prebootstrap tasks. This task just make sure that the admin users are allowed. 