### PR TITLE
Add bash-completion to default package installation list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ uu_email_alerts: foo@mydomain.com
 swap_file_size: "{{ (ansible_memtotal_mb / 2)|round|int }}MB"
 
 # This works with AWS images of Debian and Ubuntu
-admin_user: "{{  'admin' if (ansible_distribution == 'Debian') else 'ubuntu' }}"
+admin_user: "{{ 'admin' if (ansible_distribution == 'Debian') else 'ubuntu' }}"
 deploy_user_group: "{{ deploy_username if (deploy_username_group is not defined) else deploy_username_group }}"
 
 # Time zone
@@ -15,6 +15,7 @@ ntp_timezone: UTC
 sb_debian_base_extra_packages:
   - atsar
   - atop
+  - bash-completion
   - curl
   - emacs24-nox
   - git


### PR DESCRIPTION
From the package description:
> Programmable completion for the bash shell
 bash completion extends bash's standard completion behavior to achieve
 complex command lines with just a few keystrokes.  This project was
 conceived to produce programmable completion routines for the most
 common Linux/UNIX commands, reducing the amount of typing sysadmins
 and programmers need to do on a daily basis.
