### PR TITLE
Remove atsar from default installation list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,6 @@ ntp_timezone: UTC
 
 # Extra packages
 sb_debian_base_extra_packages:
-  - atsar
   - atop
   - bash-completion
   - curl


### PR DESCRIPTION
It is no longer available in the latest LTS version of Ubuntu 16.04.