### PR TITLE
Remove duplicated SSH keys related code

### DIFF
--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -40,6 +40,7 @@
   apt:
     upgrade: dist
     update_cache: yes
+    cache_valid_time: 3600
 
 - name: Install extra packages
   apt:

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -1,10 +1,5 @@
 ---
-- name: Make sure that the authorized_keys file is set for the admin user
-  authorized_key:
-    user: "{{ sb_debian_base_admin_user }}"
-    key:  "{{ item }}"
-  with_file:
-    - keys/administrators
+- include: set-authorized-keys-admin.yml
 
 - name: Disallow SSH password authentication
   lineinfile:

--- a/tasks/haskell-stack.yml
+++ b/tasks/haskell-stack.yml
@@ -34,3 +34,4 @@
     name: stack
     state: present
     update_cache: yes
+    cache_valid_time: 3600

--- a/tasks/prebootstrap.yml
+++ b/tasks/prebootstrap.yml
@@ -7,14 +7,11 @@
     groups: sudo
     append: yes
 
-- name: Update packages cache
-  apt:
-    update_cache: yes
-
 - name: Install sudo package
   apt:
     name: sudo
     state: latest
+    update_cache: yes
 
 - name: Use sudo without password
   lineinfile:
@@ -24,9 +21,4 @@
     line: '%sudo ALL=(ALL) NOPASSWD: ALL'
     validate: 'visudo -cf %s'
 
-- name: Set up authorized_keys file for the admin user
-  authorized_key:
-    user: "{{ sb_debian_base_admin_user }}"
-    key:  "{{ item }}"
-  with_file:
-    - keys/administrators
+- include: set-authorized-keys-admin.yml

--- a/tasks/set-authorized-keys-admin.yml
+++ b/tasks/set-authorized-keys-admin.yml
@@ -1,0 +1,9 @@
+---
+- name: Set up authorized_keys file for the admin user
+  authorized_key:
+    user: "{{ sb_debian_base_admin_user }}"
+    key:  "{{ item }}"
+    state: present
+    exclusive: yes
+  with_file:
+    - keys/administrators

--- a/tasks/set-authorized-keys.yml
+++ b/tasks/set-authorized-keys.yml
@@ -1,12 +1,5 @@
 ---
-- name: Set up authorized_keys file for the admin user
-  authorized_key:
-    user: "{{ sb_debian_base_admin_user }}"
-    key:  "{{ item }}"
-    state: present
-    exclusive: yes
-  with_file:
-    - keys/administrators
+- include: set-authorized-keys-admin.yml
 
 - name: Set up authorized_keys file for the deploy user
   authorized_key:


### PR DESCRIPTION
This does:
* Removes duplicate code related to the update of authorized SSH keys.
* And only update apt cache if it's older than one hour.