### PR TITLE
Add variable sb_debian_base_supplementary_packages to allow users install extra apt packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## MASTER
 
+## 1.3.3
+* Added sb_debian_base_supplementary_packages variable to allow the installation of more packages additionally to sb_debian_base_extra_packages
+
 ## 1.3.2
 * Don't disable IPv6 connections on Debian's firewall
 * Minor cleanups

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This tag contains more advance setup tasks, such as:
 - Upgrade all packages
 - Install basic packages
     - e.g.: vim, tmux, htop, atop, tree, ufw, emacs, git, curl
+- Install supplementary packages - not just sb_debian_base_extra_packages
 - Enable UFW
     - Open general ports (e.g. SSH port, HTTP port; by default SSH)
         - You can define {{ ports }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,5 @@ sb_debian_base_extra_packages:
   - tree
   - ufw
   - vim
+
+sb_debian_base_supplementary_packages: []

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -41,7 +41,7 @@
   apt:
     name: "{{ item }}"
     state: latest
-  with_items: "{{ sb_debian_base_extra_packages }}"
+  with_items: "{{ sb_debian_base_extra_packages | union(sb_debian_base_supplementary_packages) }}"
 
 - include: bootstrap-firewall.yml
   when: sb_debian_base_firewall

--- a/tests/site.yml
+++ b/tests/site.yml
@@ -19,3 +19,4 @@
         sb_debian_base_swap_file_size: no
         sb_debian_base_deploy_user: deployer
         sb_debian_base_deploy_user_private_key: "DEPLOY_USER_PRIVATE_KEY"
+        sb_debian_base_supplementary_packages: [ "pkg-config", "traceroute" ]


### PR DESCRIPTION
Add sb_debian_base_supplementary_packages variable to allow the installation of extra deb packages.