### PR TITLE
Fix deprecation warnings for using include (fix #95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## MASTER
 
+## 1.4.2
+* Fix deprecation warnings for using include.
+
 ## 1.4.1
 * Move GitHub known host to the varible sb_debian_base_known_host
 

--- a/tasks/bootstrap-deploy-user.yml
+++ b/tasks/bootstrap-deploy-user.yml
@@ -21,7 +21,7 @@
   tags:
     - create-app-directory
 
-- include: set-authorized-keys-user.yml
+- import_tasks: set-authorized-keys-user.yml
 
 - name: Add deploy user's SSH private key
   copy:

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -1,5 +1,5 @@
 ---
-- include: set-authorized-keys-admin.yml
+- import_tasks: set-authorized-keys-admin.yml
 
 - name: Disallow SSH password authentication
   lineinfile:
@@ -43,8 +43,8 @@
     state: latest
   with_items: "{{ sb_debian_base_extra_packages | union(sb_debian_base_supplementary_packages) }}"
 
-- include: bootstrap-firewall.yml
+- import_tasks: bootstrap-firewall.yml
   when: sb_debian_base_firewall
 
-- include: bootstrap-deploy-user.yml
+- import_tasks: bootstrap-deploy-user.yml
   when: sb_debian_base_deploy_user is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
-- include: prebootstrap.yml
+- import_tasks: prebootstrap.yml
   remote_user: root
   when: prebootstrap is defined
 
-- include: bootstrap.yml
+- import_tasks: bootstrap.yml
   remote_user: "{{ sb_debian_base_admin_user }}"
   become: yes
   when: bootstrap is defined
 
-- include: haskell-dependencies.yml
+- import_tasks: haskell-dependencies.yml
   remote_user: "{{ sb_debian_base_admin_user }}"
   become: yes
   when: install_haskell_dependencies is defined
 
-- include: haskell-stack.yml
+- import_tasks: haskell-stack.yml
   remote_user: "{{ sb_debian_base_admin_user }}"
   become: yes
   when: install_haskell_stack is defined
 
-- include: set-authorized-keys.yml
+- import_tasks: set-authorized-keys.yml
   remote_user: "{{ sb_debian_base_admin_user }}"
   become: yes
   when: add_remove_keys is defined

--- a/tasks/prebootstrap.yml
+++ b/tasks/prebootstrap.yml
@@ -21,4 +21,4 @@
     line: '%sudo ALL=(ALL) NOPASSWD: ALL'
     validate: 'visudo -cf %s'
 
-- include: set-authorized-keys-admin.yml
+- import_tasks: set-authorized-keys-admin.yml

--- a/tasks/set-authorized-keys.yml
+++ b/tasks/set-authorized-keys.yml
@@ -1,5 +1,5 @@
 ---
-- include: set-authorized-keys-admin.yml
+- import_tasks: set-authorized-keys-admin.yml
 
-- include: set-authorized-keys-user.yml
+- import_tasks: set-authorized-keys-user.yml
   when: sb_debian_base_deploy_user is defined


### PR DESCRIPTION
This PR fixes the new Ansible 2.4 warnings related to using import for tasks (#95). There are still warnings but those are from dependencies.