### PR TITLE
Make sure D-Bus is present before executing commands that need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## MASTER
 
+## 1.4.4
+* Make sure D-Bus is present before executing commands that need it.
+
 ## 1.4.3
 * Use task to restart ssh instead of handler.
 

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -15,10 +15,17 @@
     line: "PermitRootLogin no"
     state: present
 
-- name: restart ssh
+- name: Restart SSH service
   service:
     name: ssh
     state: restarted
+
+- name: Make sure D-Bus is installed
+  apt:
+    name: dbus
+    state: installed
+    update_cache: yes
+    cache_valid_time: 3600
 
 - name: Set hostname to host-specific variable
   hostname:


### PR DESCRIPTION
As settings the hostname and timezone requires dbus, and this packages is not present on minimal installation images.