### PR TITLE
Add journald persistent storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-tests/external-roles/
+.#*
 tests/*.retry
+tests/external-roles/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
 ## MASTER
+
+## 1.4.5
 * Move groups of tasks from the main bootstrap file to individual files.
+* Store journald data persistently on storage.
 
 ## 1.4.4
 * Make sure D-Bus is present before executing commands that need it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # CHANGELOG
 
 ## MASTER
+* Move groups of tasks from the main bootstrap file to individual files.
 
 ## 1.4.4
 * Make sure D-Bus is present before executing commands that need it.
 
 ## 1.4.3
-* Use task to restart ssh instead of handler.
+* Use a task to restart the SSH server instead of a handler.
 
 ## 1.4.2
 * Fix deprecation warnings for using include.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This tag contains more advance setup tasks, such as:
 - Set time zone
     - You can define {{ sb_debian_base_ntp_timezone }}
 - Enable NTP using systemd-timesyncd
+- Make sure to store journald data persistently
 - Upgrade all packages
 - Install basic packages
     - e.g.: vim, tmux, htop, atop, tree, ufw, emacs, git, curl

--- a/tasks/bootstrap-packages.yml
+++ b/tasks/bootstrap-packages.yml
@@ -1,0 +1,12 @@
+---
+- name: Update package cache and upgrade packages
+  apt:
+    upgrade: dist
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Install extra packages
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items: "{{ sb_debian_base_extra_packages | union(sb_debian_base_supplementary_packages) }}"

--- a/tasks/bootstrap-services-and-os-settings.yml
+++ b/tasks/bootstrap-services-and-os-settings.yml
@@ -1,0 +1,21 @@
+---
+- name: Make sure D-Bus is installed
+  apt:
+    name: dbus
+    state: installed
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Set hostname to host-specific variable
+  hostname:
+    name: "{{ hostname }}"
+  when: hostname is defined
+  tags:
+    - set-hostname
+
+- name: Set the time zone
+  timezone:
+    name: "{{ sb_debian_base_ntp_timezone }}"
+
+- name: Enable NTP
+  command: timedatectl set-ntp true

--- a/tasks/bootstrap-services-and-os-settings.yml
+++ b/tasks/bootstrap-services-and-os-settings.yml
@@ -19,3 +19,11 @@
 
 - name: Enable NTP
   command: timedatectl set-ntp true
+
+- name: Store journald data persistently
+  lineinfile:
+    dest: /etc/systemd/journald.conf
+    regexp: "^#?Storage="
+    line: "Storage=persistent"
+    state: present
+  when: ansible_distribution_release != "trusty"

--- a/tasks/bootstrap-ssh.yml
+++ b/tasks/bootstrap-ssh.yml
@@ -1,0 +1,20 @@
+---
+- name: Disallow SSH password authentication
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^PasswordAuthentication"
+    line: "PasswordAuthentication no"
+    state: present
+
+- name: Disallow root SSH access
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^PermitRootLogin"
+    line: "PermitRootLogin no"
+    state: present
+
+# Here we restart the SSH service immediately instead of using handlers.
+- name: Restart SSH service
+  service:
+    name: ssh
+    state: restarted

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -1,57 +1,11 @@
 ---
 - import_tasks: set-authorized-keys-admin.yml
 
-- name: Disallow SSH password authentication
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: "^PasswordAuthentication"
-    line: "PasswordAuthentication no"
-    state: present
+- import_tasks: bootstrap-ssh.yml
+  
+- import_tasks: bootstrap-services-and-os-settings.yml
 
-- name: Disallow root SSH access
-  lineinfile:
-    dest: /etc/ssh/sshd_config
-    regexp: "^PermitRootLogin"
-    line: "PermitRootLogin no"
-    state: present
-
-- name: Restart SSH service
-  service:
-    name: ssh
-    state: restarted
-
-- name: Make sure D-Bus is installed
-  apt:
-    name: dbus
-    state: installed
-    update_cache: yes
-    cache_valid_time: 3600
-
-- name: Set hostname to host-specific variable
-  hostname:
-    name: "{{ hostname }}"
-  when: hostname is defined
-  tags:
-    - set-hostname
-
-- name: Set the time zone
-  timezone:
-    name: "{{ sb_debian_base_ntp_timezone }}"
-
-- name: Enable NTP
-  command: timedatectl set-ntp true
-
-- name: Update package cache and upgrade packages
-  apt:
-    upgrade: dist
-    update_cache: yes
-    cache_valid_time: 3600
-
-- name: Install extra packages
-  apt:
-    name: "{{ item }}"
-    state: latest
-  with_items: "{{ sb_debian_base_extra_packages | union(sb_debian_base_supplementary_packages) }}"
+- import_tasks: bootstrap-packages.yml
 
 - import_tasks: bootstrap-firewall.yml
   when: sb_debian_base_firewall

--- a/tasks/haskell-stack.yml
+++ b/tasks/haskell-stack.yml
@@ -1,17 +1,17 @@
 ---
-- name: Add FPCO's PGP public key
+- name: Add FPCO’s PGP public key
   apt_key:
     url: 'https://s3.amazonaws.com/download.fpcomplete.com/{{ ansible_distribution | lower }}/fpco.key'
     state: present
 
 # There is no specific repo for Stretch
-- name: Add FPCO's deb repository (Debian)
+- name: Add FPCO’s deb repository (Debian)
   apt_repository:
     repo: 'deb http://download.fpcomplete.com/debian/jessie stable main'
     state: present
   when: ansible_distribution == "Debian"
 
-- name: Add FPCO's deb repository (Ubuntu)
+- name: Add FPCO’s deb repository (Ubuntu)
   apt_repository:
     repo: 'deb http://download.fpcomplete.com/ubuntu {{ ansible_distribution_release }} main'
     state: present


### PR DESCRIPTION
This changes `journald.conf` to make sure the data is stored permanently on the storage device. In the other commit, a small refactor of the main bootstrap task in order to help adding the first change.

According to the [man page](https://www.freedesktop.org/software/systemd/man/journald.conf.html#SystemMaxUse=), the storage value is 10% of the file system size, but capped to 4 GB.