### PR TITLE
Add `acl` to `sb_debian_extra_packages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # CHANGELOG
 
-## MASTER
-* Move Galaxy required packages (dependencies) to a separated list.
-* Install UFW only when sb_debian_base_firewall is true
-
-## 1.4.5
+## 1.4.6
 * Move groups of tasks from the main bootstrap file to individual files.
 * Store journald data persistently on storage.
+* Add `acl` to `sb_debian_base_packages` as it is steadily being removed as a `systemd` dependency in supported distros
 
 ## 1.4.4
 * Make sure D-Bus is present before executing commands that need it.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,5 @@
 ---
 sb_debian_base_deploy_user_dir: "/home/{{ sb_debian_base_deploy_user }}"
 sb_debian_base_packages:
+  - acl
   - dbus


### PR DESCRIPTION
In Debian Stretch, `systemd` no longer depends on `acl`, which is needed to use ssh pipelining. 