### PR TITLE
Environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## MASTER
 
+## 1.5.0
+* Fix minimum Ansible version.
+* Change variable name sb_debian_base_app_path to sb_debian_base_project_path
+* Add task to update environment variables.
 
 ## 1.4.6
 * Move Galaxy required packages (dependencies) to a separated list.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ As an example you can use `tests/site.yml` or the one below:
       add_remove_keys: yes
       vars:
         sb_debian_base_deploy_user: deployer
+        sb_debian_base_supplementary_packages: [ "pkg-config", "traceroute" ]
+        sb_debian_base_environment_variables:
+          ONE: "uno"
+          TWO: "dos"
 ```
 
 You can also run ad-hoc tasks, although it's not the recommended way:
@@ -94,7 +98,9 @@ This tag contains more advance setup tasks, such as:
         - You can define {{ ports }}
     - Open specific ports for specific IPs
         - You can define {{ port_ips }}
-- Create user and group for deployer user
+- Set and update environment variables
+    - You need to define {{ sb_debian_base_environment_variables }}
+- Create Unix user and group for deployer user
     - You need to define the var {{ sb_debian_base_deploy_user }} (e.g. deployer)
     - Optionally define the var {{ sb_debian_base_deploy_user_group }} (e.g. deployer)
       otherwise, it will be the same as {{ sb_debian_base_deploy_user }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/stackbuilders/sb-debian-base.svg?branch=master)](https://travis-ci.org/stackbuilders/sb-debian-base)
 [![Ansible Galaxy](https://img.shields.io/badge/role-sb--debian--base-blue.svg)](https://galaxy.ansible.com/stackbuilders/sb-debian-base/)
 
-Generic Debian image for servers. This Galaxy requires Ansible 2.2.1
+Generic Debian image for servers. This Galaxy requires Ansible 2.4.0
 
 ## How to use this role
 The current version uses Ansible flow control (when: foo is defined) to run tasks

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,18 @@
 ---
-# Defaults file
-sb_debian_base_app_path: /var/projects
+# System
 sb_debian_base_uu_email_alerts: "{{ sb_debian_base_admin_user }}@localhost"
 sb_debian_base_swap_file_size: "{{ (ansible_memtotal_mb / 2)|round|int }}MB"
 
-# This works with AWS images of Debian and Ubuntu
+# Application
+sb_debian_base_project_path: /var/projects
+sb_debian_base_app_path: "{{ sb_debian_base_project_path }}/{{ sb_debian_base_app_name }}"
+sb_debian_base_environment_vars:
+  path: "{{ sb_debian_base_app_path }}/shared"
+  path_mode: '0750'
+  file_: "{{ sb_debian_base_app_path }}/shared/{{ sb_debian_base_app_name }}.env"
+  file_mode: '0640'
+
+# Compatible with AWS images of Debian and Ubuntu
 sb_debian_base_admin_user: "{{ 'admin' if (ansible_distribution == 'Debian') else 'ubuntu' }}"
 sb_debian_base_deploy_user_group: "{{ sb_debian_base_deploy_user if (sb_debian_base_deploy_user is defined) else '' }}"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Base image and common roles
   company: Stack Builders
   license: MIT
-  min_ansible_version: 2.2.1
+  min_ansible_version: 2.4.0
   platforms:
     - name: Debian
       versions:

--- a/tasks/bootstrap-deploy-user.yml
+++ b/tasks/bootstrap-deploy-user.yml
@@ -13,7 +13,7 @@
 
 - name: Create application deploy directory
   file:
-    path: "{{ sb_debian_base_app_path }}"
+    path: "{{ sb_debian_base_project_path }}"
     state: directory
     owner: "{{ sb_debian_base_deploy_user }}"
     group: "{{ sb_debian_base_deploy_user_group }}"
@@ -23,7 +23,7 @@
 
 - import_tasks: set-authorized-keys-user.yml
 
-- name: Add deploy user's SSH private key
+- name: Add deploy user’s SSH private key
   copy:
     dest:  "{{ sb_debian_base_deploy_user_dir }}/.ssh/id_rsa"
     content: "{{ sb_debian_base_deploy_user_private_key }}"

--- a/tasks/bootstrap-environment-variables.yml
+++ b/tasks/bootstrap-environment-variables.yml
@@ -1,0 +1,21 @@
+---
+- name: Create environment variables directories
+  file:
+    path: "{{ sb_debian_base_environment_vars.path }}"
+    state: directory
+    recurse: yes
+    mode: "{{ sb_debian_base_environment_vars.path_mode }}"
+    owner: "{{ sb_debian_base_deploy_user }}"
+    group: "{{ sb_debian_base_deploy_user_group }}"
+
+- name: Add environment variables
+  lineinfile:
+    create: yes
+    dest: "{{ sb_debian_base_environment_vars.file_ }}"
+    regexp: "^{{ item.key }}="
+    line: "{{ item.key }}={{ item.value }}"
+    state: present
+    mode: "{{ sb_debian_base_environment_vars.file_mode }}"
+    owner: "{{ sb_debian_base_deploy_user }}"
+    group: "{{ sb_debian_base_deploy_user_group }}"
+  with_dict: "{{ sb_debian_base_environment_variables }}"

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -14,5 +14,6 @@
   when: sb_debian_base_deploy_user is defined
 
 - import_tasks: bootstrap-environment-variables.yml
+  when: sb_debian_base_environment_variables is defined
   tags:
     - env-vars

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -12,3 +12,7 @@
 
 - import_tasks: bootstrap-deploy-user.yml
   when: sb_debian_base_deploy_user is defined
+
+- import_tasks: bootstrap-environment-variables.yml
+  tags:
+    - env-vars

--- a/tests/site.yml
+++ b/tests/site.yml
@@ -16,7 +16,11 @@
       install_haskell_dependencies: yes
       add_remove_keys: yes
       vars:
-        sb_debian_base_swap_file_size: no
+        sb_debian_base_app_name: example
         sb_debian_base_deploy_user: deployer
         sb_debian_base_deploy_user_private_key: "DEPLOY_USER_PRIVATE_KEY"
         sb_debian_base_supplementary_packages: [ "pkg-config", "traceroute" ]
+        sb_debian_base_swap_file_size: no
+        sb_debian_base_environment_variables:
+          ONE: "uno"
+          TWO: "dos"


### PR DESCRIPTION
Add a task to update environment variables. Path, filename and permissions are configurable overwriting the default variables.

This renames the variable `sb_debian_base_app_path` to `sb_debian_base_project_path`, as the name was misleading and now we are using both variables.

This also fixes the minimum Ansible version.