### PR TITLE
Fix setting of recursive permissions on default shared folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## MASTER
 
+## 1.5.1
+* Fix setting of recursive permissions when updating environment variables.
+* Update README.md
+
 ## 1.5.0
 * Fix minimum Ansible version.
 * Change variable name sb_debian_base_app_path to sb_debian_base_project_path

--- a/tasks/bootstrap-environment-variables.yml
+++ b/tasks/bootstrap-environment-variables.yml
@@ -3,7 +3,6 @@
   file:
     path: "{{ sb_debian_base_environment_vars.path }}"
     state: directory
-    recurse: yes
     mode: "{{ sb_debian_base_environment_vars.path_mode }}"
     owner: "{{ sb_debian_base_deploy_user }}"
     group: "{{ sb_debian_base_deploy_user_group }}"


### PR DESCRIPTION
Permissions where being propagated to subfolders on the environment variables path. 