### PR TITLE
Update ansible_min_version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ python:
   - "3.6"
 
 env:
-  - REQUIREMENTS_FILE=requirements-2.4.txt
-  - REQUIREMENTS_FILE=requirements-2.5.txt
   - REQUIREMENTS_FILE=requirements-2.6.txt
   - REQUIREMENTS_FILE=requirements-2.7.txt
   - REQUIREMENTS_FILE=requirements-2.8.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.6.4
+* Drop Ansible 2.4.0 and 2.5.0 support
+
 ## 1.6.3
 * Replace kamaln7.swapfile with geerlingguy.swap requeriment role.
 
@@ -7,7 +10,6 @@
 * Remove package emacs24-nox ,to work arround issue #114
 * Add Debian 10 support
 * Drop Ubuntu 14.04 support
-* Drop Ansible 2.4.0 and 2.5.0 support
 
 ## 1.6.1
 * Add webhooks into travis.yml to notifiy galaxy about new releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Remove package emacs24-nox ,to work arround issue #114
 * Add Debian 10 support
 * Drop Ubuntu 14.04 support
+* Drop Ansible 2.4.0 and 2.5.0 support
 
 ## 1.6.1
 * Add webhooks into travis.yml to notifiy galaxy about new releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 1.6.4
+## 1.7.0
 * Drop Ansible 2.4.0 and 2.5.0 support
 
 ## 1.6.3

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/stackbuilders/sb-debian-base.svg?branch=master)](https://travis-ci.org/stackbuilders/sb-debian-base)
 [![Ansible Galaxy](https://img.shields.io/badge/role-sb--debian--base-blue.svg)](https://galaxy.ansible.com/stackbuilders/sb-debian-base/)
 
-Generic Debian image for servers. This Galaxy requires Ansible 2.4.0
+Generic Debian image for servers. This Galaxy requires Ansible 2.6.0
 
 ## Supported Platforms
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Base image and common roles
   company: Stack Builders
   license: MIT
-  min_ansible_version: 2.4.0
+  min_ansible_version: 2.6.0
   platforms:
     - name: Debian
       versions:

--- a/requirements-2.4.txt
+++ b/requirements-2.4.txt
@@ -1,3 +1,0 @@
-ansible~=2.4.0
-docker~=3.5
-molecule~=2.19

--- a/requirements-2.5.txt
+++ b/requirements-2.5.txt
@@ -1,3 +1,0 @@
-ansible~=2.5.0
-docker~=3.5
-molecule~=2.19


### PR DESCRIPTION
This PR updates the min_ansible version that it's necessary to run this role. The ansible_min_version is 2.6.0 that is the minor supported version.
