### PR TITLE
[#142] Removing MB in the swapfile variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Removed
 
 # CHANGELOG
 
+## 1.7.2
+* Remove `MB` text in `sb_debian_base_swapfile_size` variable to avoid a swap file filling the whole disk space.
+
 ## 1.7.1
 * Drop Ansible 2.6.0 support [Ansible releases](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # System
 sb_debian_base_uu_email_alerts: "{{ sb_debian_base_admin_user }}@localhost"
-sb_debian_base_swap_file_size: "{{ (ansible_memtotal_mb / 2)|round|int }}MB"
+sb_debian_base_swap_file_size: "{{ (ansible_memtotal_mb / 2)|round|int }}"
 
 # Application
 sb_debian_base_project_path: /var/projects


### PR DESCRIPTION
This PR fixes the bug of getting a swapfile that fill the whole disk space mentioned in the #142 issue.